### PR TITLE
ドラッグ＆ドロップエリア全体をクリック可能に改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,28 @@
             cursor: pointer;
         }
         .upload-section {
-            text-align: center;
             margin-bottom: 30px;
+        }
+        .upload-area {
+            display: block;
+            text-align: center;
             padding: 20px;
             border: 2px dashed #ccc;
             border-radius: 8px;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+        }
+        .upload-area:hover {
+            background-color: #f0f0f0;
+        }
+        .upload-text {
+            color: #003f87;
+            font-weight: bold;
+            margin-bottom: 10px;
+        }
+        #uploadStatus {
+            margin: 0;
+            color: #666;
         }
         .month-section {
             margin-bottom: 20px;
@@ -95,13 +112,14 @@
             <input type="text" id="lat" placeholder="35.6581">
             <label for="lng">経度:</label>
             <input type="text" id="lng" placeholder="139.7017">
+            <div id="maps-link" style="margin-top: 15px;"></div>
         </div>
         <div class="upload-section">
             <input type="file" id="fileInput" accept=".json" style="display: none;">
-            <label for="fileInput" class="upload-button">
-                <span>JSONファイルを選択</span>
+            <label for="fileInput" class="upload-area">
+                <div class="upload-text">JSONファイルを選択</div>
+                <p id="uploadStatus">またはファイルをここにドラッグ＆ドロップ</p>
             </label>
-            <p id="uploadStatus">またはファイルをここにドラッグ＆ドロップ</p>
         </div>
         <div id="result"></div>
     </div>


### PR DESCRIPTION
## 変更内容

- ドラッグ＆ドロップエリア全体をクリック可能に変更
- ホバー時の視覚的フィードバックを追加（背景色が変化）
- レイアウトを整理し、より直感的なデザインに改善
- ファイル選択とドラッグ＆ドロップの両方の操作がエリア全体で可能に

## 動作確認項目
- [x] エリアのどの部分をクリックしてもファイル選択ダイアログが開く
- [x] ドラッグ＆ドロップが正常に機能する
- [x] ホバー時に背景色が変化する